### PR TITLE
Fix: Correct status display in README and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ blkprxy is a free, zero-config CORS proxy designed for developers who need to in
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/iambhvsh/blkprxy)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Status](https://img.shields.io/website?url=https%3A%2F%2Fblkprxy.vercel.app&label=API%20Status)](https://blkprxy.vercel.app)
+[![Status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fblkprxy.vercel.app%2Fapi%2Fhealth&query=%24.message&label=status&color=green)](https://blkprxy.vercel.app/api/health)
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -243,7 +243,7 @@ fetch(proxyUrl)
             // Periodically checks the proxy's health endpoint and updates the UI indicator.
             const statusIndicator = document.getElementById('status-indicator');
             const statusText = document.getElementById('status-text');
-            const healthCheckUrl = 'https://blkprxy.vercel.app/api/health';
+            const healthCheckUrl = '/api/health';
             
             const checkApiStatus = async () => {
                 try {


### PR DESCRIPTION
- Updated the status badge in `README.md` to use a dynamic badge that points to the `/api/health` endpoint. This ensures the badge accurately reflects the API's operational status.
- Changed the `healthCheckUrl` in `public/index.html` to a relative path (`/api/health`) to prevent potential cross-origin issues when fetching the status.